### PR TITLE
Add pages information 

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { ProfileComponent } from './pages/profile/profile.component';
 import { GamesComponent } from './pages/games/games.component';
 import { OrdersComponent } from './pages/orders/orders.component';
 import { PreferenceListPageComponent } from './pages/preferenceList/preference-list.component';
+import { InformationComponent } from './pages/information/information.component';
 
 export const routes: Routes = [
   {
@@ -121,7 +122,11 @@ export const routes: Routes = [
           name: 'preference list',
           showInSidebar: true
         }
-      }
+      },
+      { 
+        path: 'information', 
+        component: InformationComponent 
+      },
     ],
   },
 ];

--- a/src/app/pages/information/information.component.html
+++ b/src/app/pages/information/information.component.html
@@ -1,0 +1,52 @@
+<div class="band-info-page">
+  <header class="page-header">
+    <h1>{{ bandName }}</h1>
+    <img [src]="bandImageUrl" [alt]="'Foto de ' + bandName" class="band-main-image">
+  </header>
+
+  <section class="info-section">
+    <h2>Información General</h2>
+    <p><strong>Origen:</strong> {{ origin }}</p>
+    <p><strong>Géneros:</strong> {{ genres.join(', ') }}</p>
+    <p><strong>Años en activo:</strong> {{ yearsActive }}</p>
+    <p class="band-description">{{ description }}</p>
+  </section>
+
+  <section class="info-section members-section">
+    <h2>Miembros</h2>
+    <div class="members-columns">
+      <div>
+        <h3>Actuales:</h3>
+        <ul>
+          <li *ngFor="let member of currentMembers">
+            <strong>{{ member.name }}</strong> - {{ member.role }}
+          </li>
+        </ul>
+      </div>
+      <div>
+        <h3>Anteriores (destacados):</h3>
+        <ul>
+          <li *ngFor="let member of pastMembers">
+            <strong>{{ member.name }}</strong> - {{ member.role }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="info-section discography-section">
+    <h2>Discografía (Álbumes de Estudio)</h2>
+    <div class="albums-grid">
+      <div *ngFor="let album of studioAlbums" class="album-card">
+        <img *ngIf="album.coverUrl" [src]="album.coverUrl" [alt]="'Portada de ' + album.title" class="album-cover">
+        <div class="album-details">
+          <h3>{{ album.title }} ({{ album.year }})</h3>
+          <p *ngIf="album.tracks && album.tracks.length > 0"><strong>Pistas destacadas:</strong></p>
+          <ul *ngIf="album.tracks && album.tracks.length > 0">
+            <li *ngFor="let track of album.tracks | slice:0:5">{{ track }} <span *ngIf="album.tracks.length > 5 && (album.tracks | slice:0:5).indexOf(track) === 4">...</span></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>

--- a/src/app/pages/information/information.component.scss
+++ b/src/app/pages/information/information.component.scss
@@ -1,0 +1,147 @@
+.band-info-page {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #333;
+  max-width: 1000px;
+  margin: 20px auto;
+  padding: 20px;
+  background-color: #f4f4f9;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+  .page-header {
+    text-align: center;
+    margin-bottom: 30px;
+    border-bottom: 2px solid #e0e0e0;
+    padding-bottom: 20px;
+
+    h1 {
+      font-size: 2.8em;
+      color: #2c3e50;
+      margin-bottom: 15px;
+    }
+
+    .band-main-image {
+      max-width: 100%;
+      height: auto;
+      max-height: 450px;
+      border-radius: 8px;
+      object-fit: cover;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    }
+  }
+
+  .info-section {
+    background-color: #ffffff;
+    padding: 20px;
+    margin-bottom: 25px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+
+    h2 {
+      font-size: 1.8em;
+      color: #34495e;
+      margin-top: 0;
+      margin-bottom: 15px;
+      border-bottom: 1px solid #ecf0f1;
+      padding-bottom: 10px;
+    }
+
+    p, ul {
+      font-size: 1em;
+      line-height: 1.7;
+      color: #555;
+    }
+
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+      li {
+        padding: 5px 0;
+        border-bottom: 1px dotted #eee;
+        &:last-child {
+          border-bottom: none;
+        }
+      }
+    }
+
+    .band-description {
+      font-style: italic;
+      color: #444;
+    }
+  }
+
+  .members-section {
+    .members-columns {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+
+      h3 {
+        font-size: 1.3em;
+        color: #2980b9;
+        margin-bottom: 10px;
+      }
+    }
+  }
+
+  .discography-section {
+    .albums-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+    }
+
+    .album-card {
+      background-color: #fdfdfd;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      padding: 15px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+
+      &:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 6px 15px rgba(0, 0, 0, 0.1);
+      }
+
+      .album-cover {
+        width: 150px;
+        height: 150px;
+        object-fit: cover;
+        border-radius: 4px;
+        margin-bottom: 15px;
+        box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+      }
+
+      .album-details {
+        h3 {
+          font-size: 1.4em;
+          color: #c0392b;
+          margin-bottom: 8px;
+        }
+        ul li {
+          font-size: 0.9em;
+          color: #666;
+          padding: 3px 0;
+        }
+      }
+    }
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 768px) {
+  .band-info-page .page-header h1 {
+    font-size: 2.2em;
+  }
+  .band-info-page .info-section h2 {
+    font-size: 1.6em;
+  }
+  .band-info-page .members-section .members-columns,
+  .band-info-page .discography-section .albums-grid {
+    grid-template-columns: 1fr; // Stack on smaller screens
+  }
+}

--- a/src/app/pages/information/information.component.ts
+++ b/src/app/pages/information/information.component.ts
@@ -1,0 +1,71 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common'; 
+
+interface Album {
+  title: string;
+  year: number;
+  tracks?: string[];
+  coverUrl?: string;
+}
+
+@Component({
+  selector: 'app-information',
+  standalone: true, 
+  imports: [CommonModule], 
+  templateUrl: './information.component.html',
+  styleUrls: ['./information.component.scss']
+})
+export class InformationComponent {
+  bandName: string = 'Foster the People';
+  origin: string = 'Los Ángeles, California, EE. UU.';
+  genres: string[] = ['Indie pop', 'Rock alternativo', 'Pop psicodélico', 'Dance-pop'];
+  yearsActive: string = '2009–presente';
+  
+  currentMembers: { name: string, role: string }[] = [
+    { name: 'Mark Foster', role: 'Voz principal, guitarras, teclados, sintetizadores' },
+    { name: 'Isom Innis', role: 'Teclados, piano, guitarras, bajo, batería, percusión, coros' }
+  ];
+  
+  pastMembers: { name: string, role: string }[] = [
+    { name: 'Mark Pontius', role: 'Batería, percusión, coros (2009–2021)' },
+    { name: 'Cubbie Fink', role: 'Bajo, coros (2009–2015)' },
+    { name: 'Sean Cimino', role: 'Guitarras, teclados, sintetizadores, coros (miembro de gira/sesión 2010–2017; oficial 2017–2020)' }
+  ];
+
+  description: string = `Foster the People es una banda estadounidense de indie pop formada en Los Ángeles, California, en 2009. 
+  El grupo está compuesto por el vocalista Mark Foster y el multiinstrumentista Isom Innis. El ex baterista Mark Pontius dejó la banda en 2021.
+  Alcanzaron la fama con su exitoso sencillo "Pumped Up Kicks", que se convirtió en un éxito viral en 2010 y les ayudó a conseguir un contrato con Startime International, una filial de Columbia Records. 
+  Su álbum debut, Torches, lanzado en 2011, incluyó éxitos como "Helena Beat" y "Don't Stop (Color on the Walls)". 
+  La banda ha explorado diversos sonidos a lo largo de su carrera, incorporando elementos de rock psicodélico, funk y electrónica en sus álbumes posteriores.`;
+
+  studioAlbums: Album[] = [
+    { 
+      title: 'Torches', 
+      year: 2011, 
+      tracks: ['Helena Beat', 'Pumped Up Kicks', 'Call It What You Want', 'Don\'t Stop (Color on the Walls)', 'Waste', 'I Would Do Anything for You', 'Houdini', 'Life on the Nickel', 'Missed You', 'Warrant'],
+      coverUrl: 'https://upload.wikimedia.org/wikipedia/en/5/5c/FosterThePeopleTorches.jpg'
+    },
+    { 
+      title: 'Supermodel', 
+      year: 2014, 
+      tracks: ['Are You What You Want to Be?', 'Ask Yourself', 'Coming of Age', 'Nevermind', 'Pseudologia Fantastica', 'Best Friend', 'A Beginner\'s Guide to Destroying the Moon', 'Goats in Trees', 'The Truth', 'Fire Escape'],
+      coverUrl: 'https://upload.wikimedia.org/wikipedia/en/a/ab/Foster_the_People_-_Supermodel.png'
+    },
+    { 
+      title: 'Sacred Hearts Club', 
+      year: 2017, 
+      tracks: ['Pay the Man', 'Doing It for the Money', 'Sit Next to Me', 'SHC', 'I Love My Friends', 'Static Space Lover', 'Lotus Eater', 'Loyal Like Sid & Nancy'],
+      coverUrl: 'https://upload.wikimedia.org/wikipedia/en/7/79/Sacred_Hearts_Club_Cover.jpg'
+    },
+    {
+      title: 'Paradise State of Mind',
+      year: 2024,
+      tracks: ['Lost in Space', 'Take Me Back', 'Let Go', 'Chariot', 'Under the Moon'], // Ejemplo, verificar tracklist oficial
+      coverUrl: 'https://upload.wikimedia.org/wikipedia/en/thumb/1/11/Foster_the_People_-_Paradise_State_of_Mind.png/220px-Foster_the_People_-_Paradise_State_of_Mind.png' // URL de ejemplo
+    }
+  ];
+  
+  bandImageUrl: string = 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Foster_the_People_performing_at_Lollapalooza_Chile_2019.jpg/1024px-Foster_the_People_performing_at_Lollapalooza_Chile_2019.jpg';
+
+  constructor() { }
+}


### PR DESCRIPTION
This pull request introduces a new `InformationComponent` to display detailed information about a band, including its integration into the routing system, HTML structure, styling, and TypeScript logic. The changes are grouped into the following themes:

### Routing Updates
* Added the `InformationComponent` to the application routes in `src/app/app.routes.ts`, with a new path `/information`. This allows users to navigate to the new page. [[1]](diffhunk://#diff-7d01226345966b27520a30fae71d6f3d17f54d3d06bcbc3f0dff4195fc7d9cfcR16) [[2]](diffhunk://#diff-7d01226345966b27520a30fae71d6f3d17f54d3d06bcbc3f0dff4195fc7d9cfcL124-R129)

### Component Implementation
* Created the `InformationComponent` in `src/app/pages/information/information.component.ts` to display band details, including name, origin, genres, members, description, and discography. It uses a standalone Angular component with a defined structure for albums and members.

### HTML Structure
* Added a detailed HTML template in `src/app/pages/information/information.component.html` to render the band information, including sections for general information, members, and discography. The template uses Angular directives like `*ngFor` for dynamic content rendering.

### Styling
* Introduced a new SCSS file `src/app/pages/information/information.component.scss` to style the `InformationComponent`. It includes responsive design adjustments and modern UI elements like grid layouts, shadows, and hover effects.